### PR TITLE
Permitido null em Category.parent_id

### DIFF
--- a/config/Migrations/20170120154238_CreateCategories.php
+++ b/config/Migrations/20170120154238_CreateCategories.php
@@ -16,7 +16,7 @@ class CreateCategories extends AbstractMigration
         $table->addColumn('parent_id', 'integer', [
             'default' => null,
             'limit' => 11,
-            'null' => false,
+            'null' => true,
         ]);
         $table->addColumn('lft', 'integer', [
             'default' => null,


### PR DESCRIPTION
Valor null deve ser permitido pois o primeiro (root) não tem parent_id.